### PR TITLE
added signature check in case of alg is none

### DIFF
--- a/lib/JSON/WebToken.pm
+++ b/lib/JSON/WebToken.pm
@@ -112,6 +112,9 @@ sub decode {
     }
 
     my $algorithm = $header->{alg};
+    croak "Signature must be the empty string when alg is none"
+        if $algorithm eq 'none' and $crypto_segment;
+
     unless ($class->_verify($algorithm, $signature_input, $secret, $signature)) {
         croak "Invalid signature by $signature";
     }

--- a/t/99_exception.t
+++ b/t/99_exception.t
@@ -51,6 +51,12 @@ subtest 'invalid signature' => sub {
     like $@, qr/Invalid signature/;
 };
 
+subtest 'signature must be empty' => sub {
+    my $jwt = encode_jwt { foo => 'bar' }, '', 'none';
+    eval { decode_jwt "$jwt"."xxx", 'foo' };
+    like $@, qr/Signature must be the empty string when alg is none/;
+};
+
 subtest 'is_verify true, but without secret' => sub {
     my $jwt = encode_jwt { foo => 'bar' }, 'secret';
     eval { decode_jwt $jwt };


### PR DESCRIPTION
decodeメソッドについて、alg=noneのときにsignatureの値が空かどうかのチェックを追加しました。

http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-06

> A plaintext JWT is a JWS using the "none" JWS "alg" header parameter value
> defined in JSON Web Algorithms (JWA) [JWA]; it is a JWS with the
> empty string for its JWS Signature value.
