### PR TITLE
Canonical JWT encoding

### DIFF
--- a/lib/JSON/WebToken.pm
+++ b/lib/JSON/WebToken.pm
@@ -9,7 +9,7 @@ our $VERSION = '0.08';
 use parent 'Exporter';
 
 use Carp qw(croak);
-use JSON qw(encode_json decode_json);
+use JSON qw(decode_json);
 use MIME::Base64 qw(encode_base64 decode_base64);
 use Module::Runtime qw(use_module);
 
@@ -80,8 +80,8 @@ sub encode {
         );
     }
 
-    my $header_segment  = encode_base64url(encode_json $header);
-    my $claims_segment  = encode_base64url(encode_json $claims);
+    my $header_segment  = encode_base64url(_encode_json($header));
+    my $claims_segment  = encode_base64url(_encode_json($claims));
     my $signature_input = join '.', $header_segment, $claims_segment;
 
     my $signature = $class->_sign($algorithm, $signature_input, $secret);
@@ -92,6 +92,11 @@ sub encode {
 sub encode_jwt {
     local $Carp::CarpLevel = $Carp::CarpLevel + 1;
     __PACKAGE__->encode(@_);
+}
+
+my $JSON; # cache
+sub _encode_json {
+    return ($JSON ||= JSON->new->utf8->canonical)->encode($_[0]);
 }
 
 sub decode {

--- a/t/spec/draft-ietf-jose-json-web-signature-08-A1.hmac_sha256.t
+++ b/t/spec/draft-ietf-jose-json-web-signature-08-A1.hmac_sha256.t
@@ -28,7 +28,7 @@ my $secret = pack 'C*' => @{ [
 ] };
 
 my $guard = mock_guard('JSON::WebToken' => {
-    encode_json => sub {
+    _encode_json => sub {
         my $array = [$header, $claims];
         sub { shift @$array };
     }->(),

--- a/t/spec/draft-ietf-jose-json-web-signature-08-A2.rsa_sha256.t
+++ b/t/spec/draft-ietf-jose-json-web-signature-08-A2.rsa_sha256.t
@@ -111,7 +111,7 @@ ok $rsa->verify($singing_input, $S);
 
 my $guard = mock_guard(
     'JSON::WebToken' => {
-        encode_json => sub {
+        _encode_json => sub {
             my $array = [$header, $claims];
             sub { shift @$array };
         }->(),

--- a/t/spec/draft-ietf-oauth-json-web-token-06-3.1.example.t
+++ b/t/spec/draft-ietf-oauth-json-web-token-06-3.1.example.t
@@ -29,7 +29,7 @@ my $claims = pack 'C*' => @{ [
 my $secret = '';
 
 my $guard = mock_guard('JSON::WebToken' => {
-    encode_json => sub {
+    _encode_json => sub {
         my $array = [$header, $claims];
         sub { shift @$array };
     }->(),


### PR DESCRIPTION
From perl v5.18, the key order of hash is randomized and two JSON encoded strings may be different even if they come from same structure of hash.

Encoding to JWT has same problem.

```
#!/usr/bin/env perl
use v5.18;
use JSON::WebToken;

for (1..3) {
    my $claims = {
        sub => '1234',
        iss => 'dave',
        aud => 'tom',
    };

    say encode_jwt $claims, 'secret'; 
}
```

This simple sample code says

```
eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJ0b20iLCJzdWIiOiIxMjM0IiwiaXNzIjoiZGF2ZSJ9.bajTuYDNPetfv_Zb3OGDgSutIDq5HY6aKC9H9y1PfD4
eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0IiwiaXNzIjoiZGF2ZSIsImF1ZCI6InRvbSJ9.z2lVlConVX2YKT7xrpe4EE7IneVQTFcRjtqPxpT_xjM
eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkYXZlIiwic3ViIjoiMTIzNCIsImF1ZCI6InRvbSJ9.104dgCS4l4l49igJ4Z07PA3hVp_AGQmdTRe5uB2h2Kc
```

Encoding results are completely deferent even if they have same claims.

[JWT spec](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-30) doesn't refer to above things but I think the same JWT claims should have exactly same JWT string.

This pull-req is intended to fix that problem by using canonical JSON encoding.
