### PR TITLE
alg header checkings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+[![Build Status](https://travis-ci.org/xaicron/p5-JSON-WebToken.svg?branch=master)](https://travis-ci.org/xaicron/p5-JSON-WebToken)
 # NAME
 
 JSON::WebToken - JSON Web Token (JWT) implementation

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/xaicron/p5-JSON-WebToken.svg?branch=master)](https://travis-ci.org/xaicron/p5-JSON-WebToken)
+
 # NAME
 
 JSON::WebToken - JSON Web Token (JWT) implementation
@@ -26,7 +26,7 @@ JSON::WebToken - JSON Web Token (JWT) implementation
 
 JSON::WebToken is JSON Web Token (JWT) implementation for Perl
 
-__THIS MODULE IS ALPHA LEVEL INTERFACE.__
+**THIS MODULE IS ALPHA LEVEL INTERFACE.**
 
 # METHODS
 
@@ -71,11 +71,14 @@ If you want to create a `Plaintext JWT`, should be specify `none` for the algori
     #     'eyJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlLCJpc3MiOiJqb2UifQ',
     #     ''
 
-## decode($jwt \[, $secret, $verify\_signature, $accept\_algorithm\_none \]) : HASH
+## decode($jwt \[, $secret, $verify\_signature, $accepted\_algorithms \]) : HASH
 
 This method is decoding hash reference from JWT string.
 
-    my $claims = JSON::WebToken->decode($jwt, $secret);
+    my $claims = JSON::WebToken->decode($jwt, $secret, 1, ["RS256"]);
+
+Any signing algorithm (except "none") is acceptable by default,
+so you should check it with $accepted\_algorithms parameter.
 
 ## add\_signing\_algorithm($algorithm, $class)
 
@@ -95,7 +98,7 @@ SEE ALSO [JSON::WebToken::Crypt::HMAC](https://metacpan.org/pod/JSON::WebToken::
 
 Same as `encode()` method.
 
-## decode\_jwt($jwt \[, $secret, $verify\_signature, $accept\_algorithm\_none \]) : Hash
+## decode\_jwt($jwt \[, $secret, $verify\_signature, $accepted\_algorithms \]) : Hash
 
 Same as `decode()` method.
 
@@ -130,6 +133,10 @@ When JWT signature is invalid.
 ## ERROR\_JWT\_NOT\_SUPPORTED\_SIGNING\_ALGORITHM
 
 When given signing algorithm is not supported.
+
+## ERROR\_JWT\_UNACCEPTABLE\_ALGORITHM
+
+When given signing algorithm is not included in acceptable\_algorithms.
 
 # AUTHOR
 

--- a/lib/JSON/WebToken.pm
+++ b/lib/JSON/WebToken.pm
@@ -98,10 +98,10 @@ sub decode {
     my ($class, $jwt, $secret, $verify_signature, $accepted_algorithms) = @_;
 
     if (ref $accepted_algorithms eq 'ARRAY') {
-        $accepted_algorithms = $accepted_algorithms;
+        # do nothing
     }
     elsif (defined $accepted_algorithms) {
-        if ($accepted_algorithms =~/^[0|1]$/) {
+        if ($accepted_algorithms =~/^[01]$/) {
             warn "accept_algorithm none is deprecated"; 
             $accepted_algorithms = [ grep { $_ ne "none" || !! $accepted_algorithms } (keys %$ALGORITHM_MAP) ];
         }

--- a/lib/JSON/WebToken.pm
+++ b/lib/JSON/WebToken.pm
@@ -53,6 +53,8 @@ our $ALGORITHM_MAP = {
 #    A256GCM         => '',
 #};
 
+our $DEFAULT_ALLOWED_ALGORITHMS = [ grep { $_ ne "none" } (keys %$ALGORITHM_MAP) ];
+
 sub encode {
     my ($class, $claims, $secret, $algorithm, $extra_headers) = @_;
     unless (ref $claims eq 'HASH') {
@@ -103,14 +105,15 @@ sub decode {
     elsif (defined $accepted_algorithms) {
         if ($accepted_algorithms =~/^[01]$/) {
             warn "accept_algorithm none is deprecated"; 
-            $accepted_algorithms = [ grep { $_ ne "none" || !! $accepted_algorithms } (keys %$ALGORITHM_MAP) ];
+            $accepted_algorithms = !!$accepted_algorithms ? 
+                [@$DEFAULT_ALLOWED_ALGORITHMS, "none"] :  $DEFAULT_ALLOWED_ALGORITHMS;
         }
         else {
             $accepted_algorithms = [ $accepted_algorithms ] ;
         }
     }
     else {
-        $accepted_algorithms = [ grep { $_ ne "none" } (keys %$ALGORITHM_MAP) ];
+        $accepted_algorithms = $DEFAULT_ALLOWED_ALGORITHMS;
     }
     
     unless (defined $jwt) {
@@ -197,6 +200,7 @@ sub add_signing_algorithm {
             message => 'Usage: JSON::WebToken->add_signing_algorithm($algorithm, $signing_class)',
         );
     }
+    push(@$DEFAULT_ALLOWED_ALGORITHMS, $algorithm);
     $ALGORITHM_MAP->{$algorithm} = $signing_class;
 }
 


### PR DESCRIPTION
脆弱性のコミットです。

現状の仕様だと、alg headerのチェックを推奨してないので、以下のようなコードでユーサーの意図に反して検証が通ります。

```

my $attacking_jwt = encode_jwt($claims, $pub_key, "HS256"); # hs256の秘密鍵に公開鍵を指定

# 本来RS256の検証を意図してpublic keyをわたしているが実際は、alg headerはHS256でそのsecretに$pub_keyをわたしているので通ってしまう．
decode_jwt($attacking_jwt, $pub_key);

```
